### PR TITLE
Resolves #12

### DIFF
--- a/examples/analyze.py
+++ b/examples/analyze.py
@@ -27,7 +27,7 @@ cfg = LanguageModelSAEAnalysisConfig(
     hook_points = ["blocks.3.hook_mlp_out"],
     
     # SAEConfig
-    **SAEConfig.get_hyperparameters("L3M", "results", "final.pt"),  # Load the hyperparameters from the trained model.
+    **SAEConfig.from_pretrained("result/L3M").to_dict(),  # Load the hyperparameters from the trained model.
 
     # LanguageModelSAEAnalysisConfig
     total_analyzing_tokens = 20_000_000,

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:db9c156c6c44c42ea7ac376c70f643220f7918df59cf5dd738e3a0a32caedab0"
+content_hash = "sha256:74f2e7fd31d509a6dfdce7ea59fc594fd982df38ada4b1fdd58c0eea158d9c89"
 
 [[package]]
 name = "accelerate"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "tiktoken>=0.6.0",
     "python-dotenv>=1.0.1",
     "jaxtyping>=0.2.25",
+    "safetensors>=0.4.3",
 ]
 requires-python = "==3.10.*"
 readme = "README.md"

--- a/server/app.py
+++ b/server/app.py
@@ -40,7 +40,7 @@ lm_cache = {}
 
 
 def get_model(dictionary_name: str) -> HookedTransformer:
-	cfg = LanguageModelConfig.from_pretrained_sae_path(f"{result_dir}/{dictionary_name}")
+	cfg = LanguageModelConfig.from_pretrained_sae(f"{result_dir}/{dictionary_name}")
 	if (cfg.model_name, cfg.model_from_pretrained_path) not in lm_cache:
 		hf_model = AutoModelForCausalLM.from_pretrained(
 			(
@@ -316,7 +316,7 @@ def feature_interpretation(
 		cfg = AutoInterpConfig(
 			**{
 				**SAEConfig.from_pretrained(f"{result_dir}/{dictionary_name}").to_dict(),
-				**LanguageModelConfig.from_pretrained_sae_path(f"{result_dir}/{dictionary_name}").to_dict(),
+				**LanguageModelConfig.from_pretrained_sae(f"{result_dir}/{dictionary_name}").to_dict(),
 				"openai_api_key": os.environ.get("OPENAI_API_KEY"),
 				"openai_base_url": os.environ.get("OPENAI_BASE_URL"),
 			}
@@ -332,7 +332,7 @@ def feature_interpretation(
 		cfg = AutoInterpConfig(
 			**{
 				**SAEConfig.from_pretrained(f"{result_dir}/{dictionary_name}").to_dict(),
-				**LanguageModelConfig.from_pretrained_sae_path(f"{result_dir}/{dictionary_name}").to_dict(),
+				**LanguageModelConfig.from_pretrained_sae(f"{result_dir}/{dictionary_name}").to_dict(),
 				"openai_api_key": os.environ.get("OPENAI_API_KEY"),
 				"openai_base_url": os.environ.get("OPENAI_BASE_URL"),
 			}

--- a/src/lm_saes/evals.py
+++ b/src/lm_saes/evals.py
@@ -11,14 +11,14 @@ from transformer_lens import HookedTransformer
 from lm_saes.sae import SparseAutoEncoder
 from lm_saes.activation.activation_store import ActivationStore
 # from lm_saes.activation_store_theirs import ActivationStoreTheirs
-from lm_saes.config import LanguageModelSAEConfig
+from lm_saes.config import LanguageModelSAERunnerConfig
 
 @torch.no_grad()
 def run_evals(
     model: HookedTransformer,
     sae: SparseAutoEncoder,
     activation_store: ActivationStore,
-    cfg: LanguageModelSAEConfig,
+    cfg: LanguageModelSAERunnerConfig,
     n_training_steps: int,
 ):
     ### Evals
@@ -92,7 +92,7 @@ def recons_loss_batched(
     model: HookedTransformer,
     sae: SparseAutoEncoder,
     activation_store: ActivationStore,
-    cfg: LanguageModelSAEConfig,
+    cfg: LanguageModelSAERunnerConfig,
     n_batches: int = 100,
 ):
     losses = []
@@ -133,7 +133,7 @@ def recons_loss_batched(
 def get_recons_loss(
     model: HookedTransformer,
     sae: SparseAutoEncoder,
-    cfg: LanguageModelSAEConfig,
+    cfg: LanguageModelSAERunnerConfig,
     batch_tokens: torch.Tensor,
 ):
     batch_tokens = batch_tokens.to(torch.int64)

--- a/src/lm_saes/runner.py
+++ b/src/lm_saes/runner.py
@@ -14,7 +14,7 @@ from lm_saes.config import (
     ActivationGenerationConfig,
     LanguageModelSAEAnalysisConfig,
     LanguageModelSAETrainingConfig,
-    LanguageModelSAEConfig,
+    LanguageModelSAERunnerConfig,
     LanguageModelSAEPruningConfig,
     FeaturesDecoderConfig,
 )
@@ -31,12 +31,7 @@ from lm_saes.analysis.features_to_logits import features_to_logits
 def language_model_sae_runner(cfg: LanguageModelSAETrainingConfig):
     cfg.save_hyperparameters()
     cfg.save_lm_config()
-    sae = SparseAutoEncoder(cfg=cfg)
-    if cfg.sae_from_pretrained_path is not None:
-        sae.load_state_dict(
-            torch.load(cfg.sae_from_pretrained_path, map_location=cfg.device)["sae"],
-            strict=cfg.strict_loading,
-        )
+    sae = SparseAutoEncoder.from_config(cfg=cfg)
 
     if cfg.finetuning:
         # Fine-tune SAE with frozen encoder weights and bias
@@ -102,12 +97,7 @@ def language_model_sae_runner(cfg: LanguageModelSAETrainingConfig):
 
 
 def language_model_sae_prune_runner(cfg: LanguageModelSAEPruningConfig):
-    sae = SparseAutoEncoder(cfg=cfg)
-    if cfg.sae_from_pretrained_path is not None:
-        sae.load_state_dict(
-            torch.load(cfg.sae_from_pretrained_path, map_location=cfg.device)["sae"],
-            strict=cfg.strict_loading,
-        )
+    sae = SparseAutoEncoder.from_config(cfg=cfg)
     hf_model = AutoModelForCausalLM.from_pretrained(
         cfg.model_name,
         cache_dir=cfg.cache_dir,
@@ -152,13 +142,8 @@ def language_model_sae_prune_runner(cfg: LanguageModelSAEPruningConfig):
         wandb.finish()
 
 
-def language_model_sae_eval_runner(cfg: LanguageModelSAEConfig):
-    sae = SparseAutoEncoder(cfg=cfg)
-    if cfg.sae_from_pretrained_path is not None:
-        sae.load_state_dict(
-            torch.load(cfg.sae_from_pretrained_path, map_location=cfg.device)["sae"],
-            strict=cfg.strict_loading,
-        )
+def language_model_sae_eval_runner(cfg: LanguageModelSAERunnerConfig):
+    sae = SparseAutoEncoder.from_config(cfg=cfg)
     hf_model = AutoModelForCausalLM.from_pretrained(
         cfg.model_name, cache_dir=cfg.cache_dir, local_files_only=cfg.local_files_only
     )
@@ -210,12 +195,7 @@ def activation_generation_runner(cfg: ActivationGenerationConfig):
 
 
 def sample_feature_activations_runner(cfg: LanguageModelSAEAnalysisConfig):
-    sae = SparseAutoEncoder(cfg=cfg)
-    if cfg.sae_from_pretrained_path is not None:
-        sae.load_state_dict(
-            torch.load(cfg.sae_from_pretrained_path, map_location=cfg.device)["sae"],
-            strict=cfg.strict_loading,
-        )
+    sae = SparseAutoEncoder.from_config(cfg=cfg)
 
     hf_model = AutoModelForCausalLM.from_pretrained(
         (
@@ -266,12 +246,7 @@ def sample_feature_activations_runner(cfg: LanguageModelSAEAnalysisConfig):
 
 @torch.no_grad()
 def features_to_logits_runner(cfg: FeaturesDecoderConfig):
-    sae = SparseAutoEncoder(cfg=cfg)
-    if cfg.sae_from_pretrained_path is not None:
-        sae.load_state_dict(
-            torch.load(cfg.sae_from_pretrained_path, map_location=cfg.device)["sae"],
-            strict=cfg.strict_loading,
-        )
+    sae = SparseAutoEncoder.from_config(cfg=cfg)
 
     hf_model = AutoModelForCausalLM.from_pretrained(
         (

--- a/src/lm_saes/sae_training.py
+++ b/src/lm_saes/sae_training.py
@@ -229,10 +229,10 @@ def train_sae(
             ):
                 # Save the model and optimizer state
                 path = os.path.join(
-                    cfg.exp_result_dir, cfg.exp_name, "checkpoints", f"{n_training_steps}.safetensor"
+                    cfg.exp_result_dir, cfg.exp_name, "checkpoints", f"{n_training_steps}.safetensors"
                 )
                 sae_module.set_decoder_norm_to_unit_norm()
-                safe.save_file(sae_module.state_dict(), path, {"version": version("lm-saes")})
+                sae_module.save_pretrained(path)
 
                 checkpoint_thresholds.pop(0)
 
@@ -252,10 +252,10 @@ def train_sae(
     # Save the final model
     if not cfg.use_ddp or cfg.rank == 0:
         path = os.path.join(
-            cfg.exp_result_dir, cfg.exp_name, "checkpoints", "final.safetensor"
+            cfg.exp_result_dir, cfg.exp_name, "checkpoints", "final.safetensors"
         )
         sae_module.set_decoder_norm_to_unit_norm()
-        safe.save_file(sae_module.state_dict(), path, {"version": version("lm-saes")})
+        sae_module.save_pretrained(path)
 
 @torch.no_grad()
 def prune_sae(
@@ -323,8 +323,8 @@ def prune_sae(
         print("Total pruned features:", (sae_module.feature_act_mask == 0).sum().item())
 
         path = os.path.join(
-            cfg.exp_result_dir, cfg.exp_name, "checkpoints", "pruned.safetensor"
+            cfg.exp_result_dir, cfg.exp_name, "checkpoints", "pruned.safetensors"
         )
-        safe.save_file(sae_module.state_dict(), path, {"version": version("lm-saes")})
+        sae_module.save_pretrained(path)
         
     return sae_module

--- a/src/lm_saes/utils/huggingface.py
+++ b/src/lm_saes/utils/huggingface.py
@@ -1,0 +1,59 @@
+# Some helper function to interact with huggingface API
+
+from typing import Optional, Union
+import os
+import shutil
+from huggingface_hub import create_repo, upload_folder, snapshot_download
+
+
+def upload_pretrained_sae_to_hf(sae_path: str, repo_id: str, private: bool = False):
+    """Upload a pretrained SAE model to huggingface model hub
+
+    Args:
+        sae_path (str): path to the local SAE model
+    """
+
+    from lm_saes.config import LanguageModelConfig
+    from lm_saes.sae import SparseAutoEncoder
+
+    # Load the model
+    sae = SparseAutoEncoder.from_pretrained(sae_path)
+    lm_config = LanguageModelConfig.from_pretrained_sae(sae_path)
+
+    # Create local temporary directory for uploading
+    folder_name = sae.cfg.hook_point_in if sae.cfg.hook_point_in == sae.cfg.hook_point_out else f"{sae.cfg.hook_point_in}-{sae.cfg.hook_point_out}"
+    os.makedirs(f"{sae_path}/{folder_name}", exist_ok=True)
+
+    try:
+        # Save the model
+        create_repo(repo_id=repo_id, private=private, exist_ok=True)
+
+        sae.save_pretrained(f"{sae_path}/{folder_name}")
+        sae.cfg.save_hyperparameters(f"{sae_path}/{folder_name}")
+        lm_config.save_lm_config(f"{sae_path}/{folder_name}")
+
+        # Upload the model
+        upload_folder(folder_path=f"{sae_path}/{folder_name}", repo_id=repo_id, path_in_repo=folder_name, commit_message=f"Upload pretrained SAE model. Hook point: {folder_name}. Language Model Name: {lm_config.model_name}")
+
+    finally:
+        # Remove the temporary directory
+        shutil.rmtree(f"{sae_path}/{folder_name}")
+
+def download_pretrained_sae_from_hf(repo_id: str, hook_point: str):
+    """Download a pretrained SAE model from huggingface model hub
+
+    Args:
+        repo_id (str): id of the repo
+        hook_point (str): hook point
+    """
+
+    snapshot_path = snapshot_download(repo_id=repo_id, allow_patterns=[f"{hook_point}/*"])
+    return os.path.join(snapshot_path, hook_point)
+
+def parse_pretrained_name_or_path(pretrained_name_or_path: str):
+    if os.path.exists(pretrained_name_or_path):
+        return pretrained_name_or_path
+    else:
+        repo_id = "/".join(pretrained_name_or_path.split("/")[:2])
+        hook_point = "/".join(pretrained_name_or_path.split("/")[2:])
+        return download_pretrained_sae_from_hf(repo_id, hook_point)


### PR DESCRIPTION
This PR includes:
- Move some neural network related configs from `RunnerConfig` to `BaseModelConfig`.
- Deprecate method `SAEConfig.get_hyperparameters`.
- Add `from_pretrained` method for `SAEConfig`, `LanguageModelConfig` and `SparseAutoEncoder`, which supports loading pretrained SAEs and their configs locally & from HuggingFace.
- Add supports for safetensors.