### PR TITLE
Add bfp16 support to inhibit transforming to fp32 when using llama3

### DIFF
--- a/TransformerLens/transformer_lens/components/abstract_attention.py
+++ b/TransformerLens/transformer_lens/components/abstract_attention.py
@@ -209,7 +209,7 @@ class AbstractAttention(ABC, nn.Module):
                 self.apply_rotary(k, 0, attention_mask)
             )  # keys are cached so no offset
 
-        if self.cfg.dtype not in [torch.float32, torch.float64]:
+        if self.cfg.dtype not in [torch.float32, torch.float64, torch.bfloat16]:
             # If using 16 bits, increase the precision to avoid numerical instabilities
             q = q.to(torch.float32)
             k = k.to(torch.float32)

--- a/TransformerLens/transformer_lens/components/rms_norm.py
+++ b/TransformerLens/transformer_lens/components/rms_norm.py
@@ -36,7 +36,7 @@ class RMSNorm(nn.Module):
     def forward(
         self, x: Float[torch.Tensor, "batch pos length"]
     ) -> Float[torch.Tensor, "batch pos length"]:
-        if self.cfg.dtype not in [torch.float32, torch.float64]:
+        if self.cfg.dtype not in [torch.float32, torch.float64, torch.bfloat16]:
             x = x.to(torch.float32)
         scale: Float[torch.Tensor, "batch pos 1"] = self.hook_scale(
             (x.pow(2).mean(-1, keepdim=True) + self.eps).sqrt()

--- a/TransformerLens/transformer_lens/components/rms_norm_pre.py
+++ b/TransformerLens/transformer_lens/components/rms_norm_pre.py
@@ -26,7 +26,7 @@ class RMSNormPre(nn.Module):
     def forward(
         self, x: Float[torch.Tensor, "batch pos length"]
     ) -> Float[torch.Tensor, "batch pos length"]:
-        if self.cfg.dtype not in [torch.float32, torch.float64]:
+        if self.cfg.dtype not in [torch.float32, torch.float64, torch.bfloat16]:
             x = x.to(torch.float32)
 
         scale: Float[torch.Tensor, "batch pos 1"] = self.hook_scale(


### PR DESCRIPTION
For Llama3, it is trained on bfp16, so we should not transform bfp16 to fp32 during inference. So I change the two precision transformations in transformer_lens. Basically, I add `torch.bfloat16` in the precision check list to avoid transformation to fp32.
1. Attention
In `abstract_attention.py`.
2. Layer Norm
In `rms_norm.py`, and `rms_norm.py` (because Llama3 use RMSnorm)
**Note**: I did not change the precision check list in `layernorm_pre.py` and `layernorm.py` because Llama3 doesn't use them. Should I also modified these two files?