### PR TITLE
feat(trainer): support param groups

### DIFF
--- a/src/lm_saes/abstract_sae.py
+++ b/src/lm_saes/abstract_sae.py
@@ -409,7 +409,11 @@ class AbstractSparseAutoEncoder(HookedRootModule, ABC):
 
     def get_parameters(self) -> list[dict[str, Any]]:
         """Get the parameters of the model for optimization."""
-        return [{"params": self.parameters()}]
+        jumprelu_params = (
+            list(self.activation_function.parameters()) if isinstance(self.activation_function, JumpReLU) else []
+        )
+        other_params = [p for p in self.parameters() if not any(p is param for param in jumprelu_params)]
+        return [{"params": other_params, "name": "others"}, {"params": jumprelu_params, "name": "jumprelu"}]
 
     def load_full_state_dict(self, state_dict: dict[str, torch.Tensor], device_mesh: DeviceMesh | None = None) -> None:
         # Extract and set dataset_average_activation_norm if present

--- a/src/lm_saes/config.py
+++ b/src/lm_saes/config.py
@@ -201,6 +201,7 @@ class TrainerConfig(BaseConfig):
     lr_end_ratio: float = 1 / 32
     lr_warm_up_steps: int | float = 5000
     lr_cool_down_steps: int | float = 0.2
+    jumprelu_lr_factor: float = 1.0
     clip_grad_norm: float = 0.0
     feature_sampling_window: int = 1000
     total_training_tokens: int = 300_000_000

--- a/src/lm_saes/sae.py
+++ b/src/lm_saes/sae.py
@@ -424,6 +424,3 @@ class SparseAutoEncoder(AbstractSparseAutoEncoder):
         else:
             label = batch[self.cfg.hook_point_out]
         return label
-
-    def get_parameters(self) -> list[dict[str, Any]]:
-        return [{"params": self.parameters()}]


### PR DESCRIPTION
This PR supports parameter groups to implement discriminative learning rates, which includes:

- Updated the `get_parameters` method in `AbstractSparseAutoEncoder` to separate parameters into groups for "others" and "jumprelu" with respective learning rates.
- Modified the `_initialize_optimizer` method in `Trainer` to apply different learning rates based on parameter group names and log detailed parameter information.
- Added a new configuration field `jumprelu_lr_factor` in `TrainerConfig` to control the learning rate for JumpReLU parameters.
