### PR TITLE
Fix batch size validation for data parallelism and adjust total count for activation processing in CachedActivationLoader

### DIFF
--- a/src/lm_saes/activation/processors/cached_activation.py
+++ b/src/lm_saes/activation/processors/cached_activation.py
@@ -240,7 +240,7 @@ class CachedActivationLoader(BaseActivationProcessor[None, Iterable[dict[str, An
         else:
             for data in tqdm(
                 dataloader,
-                total=len(cached_activation_dataset),
+                total=len(cached_activation_dataset) // self.device_mesh.size(),
                 desc="Processing activation chunks",
                 disable=not is_master(),
             ):


### PR DESCRIPTION
- Updated the batch size validation logic in `ActivationBatchler` to account for the data dimension size, ensuring consistent shapes across tensors and lists.
- Improved assertion error messages to provide clearer feedback on batch size discrepancies.
- Updated the total count in the `tqdm` progress bar to account for the device mesh size, ensuring accurate progress tracking during activation chunk processing.